### PR TITLE
Remove Spectiv Crowdsale contract

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -1029,10 +1029,6 @@
     "symbol": "SIG",
     "decimals": 18
   },
-  "0xC526560cf6Ab1755a457248CB9E8669ec7F4B78C": {
-    "name": "Spectiv Crowdsale",
-    "logo": "spectiv.svg"
-  },
   "0x617b3f8050a0BD94b6b1da02B4384eE5B4DF13F4": {
     "name": "MetaMark",
     "logo": "metamark.svg",


### PR DESCRIPTION
Not a token contract. The image is used in a different contract and can not be removed. 