### PR TITLE
Fix package.json GitHub URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/MetaMask/ethereum-contract-icons.git"
+    "url": "git+ssh://git@github.com/MetaMask/contract-metadata.git"
   },
   "keywords": [
     "ethereum",
@@ -22,9 +22,9 @@
   "author": "Dan Finlay <dan@danfinlay.com>",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/MetaMask/ethereum-contract-icons/issues"
+    "url": "https://github.com/MetaMask/contract-metadata/issues"
   },
-  "homepage": "https://github.com/MetaMask/ethereum-contract-icons#readme",
+  "homepage": "https://github.com/MetaMask/contract-metadata#readme",
   "files": [
     "index.js",
     "contract-map.json",


### PR DESCRIPTION
The `package.json` GitHub URLs were incorrect even before the renaming. They're now fixed.