### PR TITLE
Resize the BOA logo

### DIFF
--- a/images/BOA.svg
+++ b/images/BOA.svg
@@ -1,14 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 600 600" style="enable-background:new 0 0 600 600;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#0073FF;}
-</style>
-<g>
-	<path class="st0" d="M600.16,180.28l-600,0.01l0.03,79.97h36.26L25.17,546.53l-25,0l-0.01,40l599.99,0l0-40l-32.5,0.01
-		l-11.25-286.25l43.75,0L600.16,180.28z M231.94,546.42h-70.06l-11.17-286.1h92.55L231.94,546.42z M438.29,546.42h-70.06
-		l-11.17-286.1h92.55L438.29,546.42z"/>
-	<polygon class="st0" points="300.16,13.3 76.42,140.27 523.91,140.27 	"/>
-</g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 330 330"><defs><style>.cls-1{fill:#fff;}.cls-2{fill:#004f9e;}</style></defs><g id="Layer_2" data-name="Layer 2"><g id="Layer_1-2" data-name="Layer 1"><circle class="cls-1" cx="165" cy="165" r="165"/><path class="cls-2" d="M271.7,104.53H58.3v29.77h12.9l-4,106.57H58.3v14.89H271.7V240.88H260.14l-4-106.57H271.7Zm-131,136.32H115.82l-4-106.52h32.91Zm73.39,0H189.21l-4-106.52h32.92Z"/><polygon class="cls-2" points="165 42.37 85.42 89.64 244.58 89.64 165 42.37"/></g></g></svg>


### PR DESCRIPTION
The logo area displayed in the `METAMASK` is truncated by the circular mask.
I resized it to fit it.
Related to #419 

Thank you.