### PR TITLE
Add gOHM

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -342,7 +342,7 @@
     "erc20": true,
     "symbol": "gOHM",
     "decimals": 18
-  },  
+  },
   "0xDd1Ad9A21Ce722C151A836373baBe42c868cE9a4": {
     "name": "Universal Basic Income",
     "logo": "ubi.svg",

--- a/contract-map.json
+++ b/contract-map.json
@@ -336,6 +336,13 @@
     "symbol": "OHM",
     "decimals": 9
   },
+  "0x0ab87046fBb341D058F17CBC4c1133F25a20a52f": {
+    "name": "Governance OHM",
+    "logo": "gOHM.svg",
+    "erc20": true,
+    "symbol": "gOHM",
+    "decimals": 18
+  },  
   "0xDd1Ad9A21Ce722C151A836373baBe42c868cE9a4": {
     "name": "Universal Basic Income",
     "logo": "ubi.svg",

--- a/images/gOHM.svg
+++ b/images/gOHM.svg
@@ -1,0 +1,12 @@
+<svg width="227" height="227" viewBox="0 0 227 227" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="7.09375" y="7.09375" width="212.812" height="212.812" rx="106.406" fill="white"/>
+<rect width="99.88" height="99.88" transform="translate(63.5601 63.787)" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M124.396 163.44L124.396 163.667H163.44V149.593H144.159C155.76 140.804 163.213 127.141 163.213 111.797C163.213 85.282 140.956 63.787 113.5 63.787C86.0444 63.787 63.7871 85.282 63.7871 111.797C63.7871 127.141 71.2402 140.804 82.8409 149.593H63.5601V163.667H102.604L102.604 163.44V144.751C88.3779 140.273 78.0881 127.263 78.0881 111.911C78.0881 92.855 93.9426 77.407 113.5 77.407C133.058 77.407 148.912 92.855 148.912 111.911C148.912 127.263 138.622 140.273 124.396 144.751V163.44Z" fill="#708B96"/>
+<rect x="7.09375" y="7.09375" width="212.812" height="212.812" rx="106.406" stroke="url(#paint0_linear_359_154)" stroke-width="14.1875"/>
+<defs>
+<linearGradient id="paint0_linear_359_154" x1="113.5" y1="-119.175" x2="113.5" y2="363.2" gradientUnits="userSpaceOnUse">
+<stop offset="0.194948" stop-color="#708B96"/>
+<stop offset="1" stop-color="#F7FBE7"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
Add gOHM token for OlympusDAO. This token represents a wrapped claim on underlying OHM rebases. See below sources to verify information and contract address:
https://docs.olympusdao.finance/main/contracts/tokens#gohm
https://www.coingecko.com/en/coins/governance-ohm

Token Address : 0x0ab87046fBb341D058F17CBC4c1133F25a20a52f
Token Name: Governance OHM
Token Decimals: 18
Token Symbol: gOHM

*Note: Thank you @xrn for fixing the OHM v2 address to the checksum version. I made sure this address is in checksum format