### PR TITLE
add new RSR

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -224,13 +224,6 @@
     "symbol": "RSV",
     "decimals": 18
   },
-  "0x8762db106B2c2A0bccB3A80d1Ed41273552616E8": {
-    "name": "Reserve Rights (DO NOT USE)",
-    "logo": "rsr.svg",
-    "erc20": true,
-    "symbol": "RSR",
-    "decimals": 18
-  },
   "0x320623b8E4fF03373931769A31Fc52A4E78B5d70": {
     "name": "Reserve Rights",
     "logo": "rsr.svg",

--- a/contract-map.json
+++ b/contract-map.json
@@ -1,5 +1,5 @@
 {
-  "0xeDF6568618A00C6F0908Bf7758A16F76B6E04aF9":{
+  "0xeDF6568618A00C6F0908Bf7758A16F76B6E04aF9": {
     "name": "Arianee",
     "logo": "aria20.svg",
     "erc20": true,
@@ -225,6 +225,13 @@
     "decimals": 18
   },
   "0x8762db106B2c2A0bccB3A80d1Ed41273552616E8": {
+    "name": "Reserve Rights (DO NOT USE)",
+    "logo": "rsr.svg",
+    "erc20": true,
+    "symbol": "RSR",
+    "decimals": 18
+  },
+  "0x320623b8E4fF03373931769A31Fc52A4E78B5d70": {
     "name": "Reserve Rights",
     "logo": "rsr.svg",
     "erc20": true,
@@ -3156,7 +3163,7 @@
     "logo": "quiverx.svg",
     "erc20": true,
     "symbol": "QRX",
-    "decimals":18
+    "decimals": 18
   },
   "0x0beAD9a1bcc1b84D06E3f2df67E3549Fd55aB054": {
     "name": "EURxb",
@@ -3636,7 +3643,7 @@
     "erc20": true,
     "symbol": "FCL",
     "decimals": 18
-  },  
+  },
   "0x3af33bEF05C2dCb3C7288b77fe1C8d2AeBA4d789": {
     "name": "Kromatika",
     "logo": "krom.svg",


### PR DESCRIPTION
Adding info for ERC20 token 'Reserve Rights (RSR)'.

This is an Upgrade to the existing RSR token https://etherscan.io/token/0x8762db106B2c2A0bccB3A80d1Ed41273552616E8 which was pause on January 13 2022 and replaced by this new contract https://etherscan.io/token/0x320623b8e4ff03373931769a31fc52a4e78b5d70.

Token upgrade official announcement: https://medium.com/reserve-currency/reserve-rights-rsr-contract-update-scheduled-for-01-13-2022-2fd0feb6d45