### PR TITLE
Revert "Bump Node to v14"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.36.2]
-### Changed
-- **BREAKING:** Removed support for Node v12 in favor of v14 ([#137](https://github.com/MetaMask/eth-json-rpc-middleware/pull/137))
-
 ## [1.36.0]
 ### Uncategorized
 - Add release workflows ([#1071](https://github.com/MetaMask/contract-metadata/pull/1071))
@@ -25,6 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding top nfts contracts on opensea by floor price ([#1052](https://github.com/MetaMask/contract-metadata/pull/1052))
 - New release ([#1045](https://github.com/MetaMask/contract-metadata/pull/1045))
 
-[Unreleased]: https://github.com/MetaMask/contract-metadata/compare/v1.36.1...HEAD
-[1.36.1]: https://github.com/MetaMask/contract-metadata/releases/tag/v1.36.0...v1.36.1
+[Unreleased]: https://github.com/MetaMask/contract-metadata/compare/v1.36.0...HEAD
 [1.36.0]: https://github.com/MetaMask/contract-metadata/releases/tag/v1.36.0

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "test": "node test"


### PR DESCRIPTION
Reverts MetaMask/contract-metadata#1074 as there was a problem with the changelogs.