### PR TITLE
Add VIDT DAO

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -2742,6 +2742,13 @@
     "symbol": "VIDT",
     "decimals": 18
   },
+  "0x3BE7bF1A5F23BD8336787D0289B70602f1940875": {
+    "name": "VIDT DAO",
+    "logo": "VIDT.svg",
+    "erc20": true,
+    "symbol": "VIDT",
+    "decimals": 18
+  },
   "0x7064aAb39A0Fcf7221c3396719D0917a65E35515": {
     "name": "Cpollo",
     "logo": "Cpollo.svg",

--- a/contract-map.json
+++ b/contract-map.json
@@ -2739,7 +2739,7 @@
     "name": "VIDT Datalink",
     "logo": "VIDT.svg",
     "erc20": true,
-    "symbol": "VIDT",
+    "symbol": "VIDT-OLD",
     "decimals": 18
   },
   "0x3BE7bF1A5F23BD8336787D0289B70602f1940875": {


### PR DESCRIPTION
Please add VIDT DAO as we are preparing a token swap to all holders. We would prefer the old token (0xfeF4185594457050cC9c23980d301908FE057Bb1) to remain visible and therefore added it instead of replacing the info. Correct address is https://etherscan.io/address/0x3BE7bF1A5F23BD8336787D0289B70602f1940875.

For evidence ...

- https://twitter.com/VIDT_Datalink/status/1575098325376040960 
- The new contract was deployed by the same account (0x95cc85867d633db0c0abd05f6cff7d45f7ece315) 
- The new smart contract address is mentioned here https://vidt-datalink.com/swap/ 
- New tokens will be reissued 1:10 using https://swap.vidt-datalink.com and in coordination with exchanges