### PR TITLE
Add upgraded PROS token contract address

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -4498,7 +4498,7 @@
     "symbol": "AITA",
     "decimals": 18
   },
-  "0x460dDE85b3CA09e82156E37eFFf50cd07bc3F7f9": {
+  "0x915424Ac489433130d92B04096F3b96c82e92a9D": {
     "name": "Prosper",
     "logo": "PROS.svg",
     "erc20": true,

--- a/contract-map.json
+++ b/contract-map.json
@@ -4497,5 +4497,12 @@
     "erc20": true,
     "symbol": "AITA",
     "decimals": 18
+  },
+  "0x460dDE85b3CA09e82156E37eFFf50cd07bc3F7f9": {
+    "name": "Prosper",
+    "logo": "PROS.svg",
+    "erc20": true,
+    "symbol": "PROS",
+    "decimals": 18
   }
 }


### PR DESCRIPTION
Following up on this [previously merged PR](https://github.com/MetaMask/contract-metadata/pull/1398), we would like to update the contract address mapping to include our upgraded token contract address.

Our upgraded token is natively LayerZero OFT and the contract address is actually the same on both ETH and BSC (the two chains we've currently deployed to).

Project website: https://www.prosper-fi.com/

Announcement regarding the token contract upgrade: https://www.prosper-fi.com/news/token-upgrade-detailed-guide

CMC link here: https://coinmarketcap.com/currencies/prosper/

Etherscan link here: https://etherscan.io/token/0x915424Ac489433130d92B04096F3b96c82e92a9D

BSCscan link here: https://bscscan.com/token/0x915424Ac489433130d92B04096F3b96c82e92a9D

Thank you for your help! Please let us know if you have any questions.