### PR TITLE
Add SkyTrade Pro (SUSDT) token metadata

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -1,3 +1,10 @@
+"0x1f891d25a386e6f67ead37d9bfaf5c444213a134": {
+  "name": "SkyTrade Pro",
+  "logo": "images/bnb-chain/0x1f891d25a386e6f67ead37d9bfaf5c444213a134/logo.png",
+  "erc20": true,
+  "symbol": "SUSDT",
+  "decimals": 18,
+  "chainId": 56
 {
   "0x14778860E937f509e651192a90589dE711Fb88a9": {
     "name": "Cyber",


### PR DESCRIPTION
This PR adds SkyTrade Pro (SUSDT) token metadata on BNB Chain (chainId 56).

- Contract: 0x1f891D25A386e6F67ead37d9BFAf5C444213a134
- Name: SkyTrade Pro
- Symbol: SUSDT
- Decimals: 18
- Logo: images/bnb-chain/0x1f891d25a386e6f67ead37d9bfaf5c444213a134/0x1f891d25a386e6f67ead37d9bfaf5c444213a134.png