### PR TITLE
Add IOB token (ETH mainnet)

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -1,4 +1,10 @@
-{
+"0xdad68778f0a0732e232f27dc296e3602e12d108a": {
+  "name": "IO Beats",
+  "logo": "erc20:0xdad68778f0a0732e232f27dc296e3602e12d108a.svg",
+  "erc20": true,
+  "symbol": "IOB",
+  "decimals": 18
+}{
   "0x14778860E937f509e651192a90589dE711Fb88a9": {
     "name": "Cyber",
     "logo": "cyber.svg",


### PR DESCRIPTION
This PR adds the official metadata and logo for the IO Beats (IOB) ERC-20 token on Ethereum.

Token Name: IO Beats

Symbol: IOB

Network: Ethereum (EIP155:1)

Contract Address: 0xdad68778f0a0732e232f27dc296e3602e12d108a

Decimals: 18

Logo: erc20:0xdad68778f0a0732e232f27dc296e3602e12d108a.svg (optimized SVG, 256x256, transparent background)

Changes Made

Added logo file in /icons/eip155:1/

Added token entry in contract-map.json