### PR TITLE
Add IO Beats (IOB) token metadata (Polygon)

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -1,4 +1,12 @@
 {
+  "0xee09fc58439f3bd514dd5cfb3b3e383e4788ecca": {
+    "name": "IO Beats",
+    "logo": "erc20:0xee09fc58439f3bd514dd5cfb3b3e383e4788ecca.svg",
+    "erc20": true,
+    "symbol": "IOB",
+    "decimals": 18,
+},
+
   "0x14778860E937f509e651192a90589dE711Fb88a9": {
     "name": "Cyber",
     "logo": "cyber.svg",


### PR DESCRIPTION
Hello MetaMask team 👋

This PR adds the official IO Beats (IOB) token on Polygon:

Contract: 0xee09fc58439f3bd514dd5cfb3b3e383e4788ecca

Symbol: IOB

Decimals: 18

Logo: Optimized SVG (256x256, transparent)

Thank you very much for your support and for maintaining this repo 🙏 Please let me know if any adjustments are needed — I’ll be happy to update quickly.