### PR TITLE
chore: changed bitcoin naming to make it appear in search under `bit`and `bitc` search partials

### DIFF
--- a/metadata/eip155:1/erc20:0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599.json
+++ b/metadata/eip155:1/erc20:0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599.json
@@ -1,5 +1,5 @@
 {
-  "name": "Wrapped BTC",
+  "name": "Wrapped Bitcoin",
   "symbol": "WBTC",
   "decimals": 8,
   "erc20": true,


### PR DESCRIPTION
This pull request makes a minor update to the metadata for the WBTC token, correcting its name from "Wrapped BTC" to "Wrapped Bitcoin".

- Updated the `name` field in `erc20:0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599.json` from "Wrapped BTC" to "Wrapped Bitcoin" to ensure accurate token metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rename WBTC token name from Wrapped BTC to Wrapped Bitcoin in metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5832ad05fb9eb80dbca9f03c9601031f78e107c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->