### PR TITLE
chore: update readme

### DIFF
--- a/labels/README.md
+++ b/labels/README.md
@@ -29,27 +29,28 @@ Trust signals data will be organized in a hierarchical folder structure based on
 
 This structure ensures that trust signals data is organized by network (using CAIP-2 Chain IDs), and specific assets (using CAIP-19 Asset IDs).
 
-# Allowed Labels
+# Allowed Label
 
-The **Labels** system supports the following predefined categories of trust signals data. Labels are stored as an array of strings in the trust signals JSON file:
+The **Labels** system supports the following predefined categories of trust signals data. A label is stored as an enum type in the trust signals JSON file:
 
-- `malicious`
+- `verified`
+- `benign`
 - `warning`
-- `spam`
+- `malicious`
 
 ---
 
 ## Usage of Labels
 
-When adding labels for a specific asset, they should be included as an array of strings in the respective JSON file.
+When adding labels for a specific asset, they should be included a string in the respective JSON file.
 
 ## JSON Example:
 
-For an asset flagged as both `malicious` and `spam`, the JSON file would look like:
+For an asset flagged as `verified`, the JSON file would look like:
 
 ```json
 {
-  "labels": ["malicious", "spam"]
+  "label": "verified"
 }
 ```
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates labels README to use a single enum `label` (not array), revises allowed categories, and refreshes usage/example.
> 
> - **README (`labels/README.md`)**
>   - Switch representation to a single enum `label` instead of array `labels`.
>   - Revise allowed categories:
>     - Add `verified`, `benign`.
>     - Remove `spam`; keep `warning`, `malicious`.
>   - Update usage instructions and JSON example to `{"label": "verified"}`.
>   - Minor heading and wording adjustments (e.g., singular "Allowed Label").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40b740e65a4f8073eb9a96fc5cdcdc5f233994fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->