### PR TITLE
fix: filter polygon stable coins

### DIFF
--- a/labels/eip155:137/erc20:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174.json
+++ b/labels/eip155:137/erc20:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174.json
@@ -1,0 +1,3 @@
+{
+    "labels": ["stable_coin"]
+}

--- a/labels/eip155:137/erc20:0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359.json
+++ b/labels/eip155:137/erc20:0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359.json
@@ -1,0 +1,3 @@
+{
+    "labels": ["stable_coin"]
+}

--- a/labels/eip155:137/erc20:0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063.json
+++ b/labels/eip155:137/erc20:0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063.json
@@ -1,0 +1,3 @@
+{
+    "labels": ["stable_coin"]
+}

--- a/labels/eip155:137/erc20:0xc2132D05D31c914a87C6611C10748AEb04B58e8F.json
+++ b/labels/eip155:137/erc20:0xc2132D05D31c914a87C6611C10748AEb04B58e8F.json
@@ -1,0 +1,3 @@
+{
+    "labels": ["stable_coin"]
+}


### PR DESCRIPTION
This PR adds stable_coin labels for three stablecoins on Polygon (eip155:137).
Changes
Added label files for the following tokens:
USDC (Native): 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359
DAI: 0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063
USDT: 0xc2132D05D31c914a87C6611C10748AEb04B58e8F

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `stable_coin` labels for Polygon (eip155:137) ERC-20 tokens.
> 
> - New label files: `erc20:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174.json`, `erc20:0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359.json`, `erc20:0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063.json`, `erc20:0xc2132D05D31c914a87C6611C10748AEb04B58e8F.json` each setting `labels: ["stable_coin"]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8c5673722a8ad6814650ada748e2ed90d65c733. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->