### PR TITLE
fix: filter out arbitrum stablecoins

### DIFF
--- a/labels/eip155:42161/erc20:0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF.json
+++ b/labels/eip155:42161/erc20:0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF.json
@@ -1,0 +1,3 @@
+{
+    "labels": ["stable_coin"]
+}

--- a/labels/eip155:42161/erc20:0x2bcC6D6CdBbDC0a4071e48bb3B969b06B3330c07.json
+++ b/labels/eip155:42161/erc20:0x2bcC6D6CdBbDC0a4071e48bb3B969b06B3330c07.json
@@ -1,0 +1,3 @@
+{
+    "labels": ["blue_chip"]
+}

--- a/labels/eip155:42161/erc20:0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f.json
+++ b/labels/eip155:42161/erc20:0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f.json
@@ -1,0 +1,3 @@
+{
+    "labels": ["blue_chip"]
+}

--- a/labels/eip155:42161/erc20:0x82aF49447D8a07e3bd95BD0d56f35241523fBab1.json
+++ b/labels/eip155:42161/erc20:0x82aF49447D8a07e3bd95BD0d56f35241523fBab1.json
@@ -1,0 +1,3 @@
+{
+    "labels": ["blue_chip"]
+}

--- a/labels/eip155:42161/erc20:0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8.json
+++ b/labels/eip155:42161/erc20:0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8.json
@@ -1,0 +1,3 @@
+{
+    "labels": ["stable_coin"]
+}

--- a/labels/eip155:42161/erc20:0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9.json
+++ b/labels/eip155:42161/erc20:0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9.json
@@ -1,0 +1,3 @@
+{
+    "labels": ["stable_coin"]
+}


### PR DESCRIPTION
For Arbitrum (eip155:42161), added stable_coin labels for 
USDAI (0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF), 
Bridged USDC (0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8), 
and USDT (0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9). 

Also added blue_chip labels for 
Wrapped SOL (0x2bcC6D6CdBbDC0a4071e48bb3B969b06B3330c07), 
Wrapped Ether (0x82aF49447D8a07e3bd95BD0d56f35241523fBab1), 
and Wrapped BTC (0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Arbitrum (eip155:42161) ERC20 label files.
> 
> - Marks `stable_coin` for `0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF`, `0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8`, `0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9`
> - Marks `blue_chip` for `0x2bcC6D6CdBbDC0a4071e48bb3B969b06B3330c07`, `0x82aF49447D8a07e3bd95BD0d56f35241523fBab1`, `0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 543df21be5e52c47faf2333e3cd3669a5c7e49f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->