### PR TITLE
[APIPLAT-2273] Add canonical head pointers seed script, and generate

### DIFF
--- a/labels/eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52.json
+++ b/labels/eip155:1/erc20:0xB8c77482e45F1F44dE1745F52C74426C631bDD52.json
@@ -1,0 +1,4 @@
+{
+    "labels": [],
+    "canonicalHead": "eip155:56/slip44:714"
+}

--- a/labels/eip155:1/erc20:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2.json
+++ b/labels/eip155:1/erc20:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2.json
@@ -1,3 +1,4 @@
 {
-    "labels": ["blue_chip"]
+  "labels": ["blue_chip"],
+  "canonicalHead": "eip155:1/slip44:60"
 }

--- a/labels/eip155:10/erc20:0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85.json
+++ b/labels/eip155:10/erc20:0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85.json
@@ -1,6 +1,4 @@
 {
-    "labels": [
-        "stable_coin"
-    ],
+    "labels": [],
     "canonicalHead": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 }

--- a/labels/eip155:143/erc20:0x754704Bc059F8C67012fEd69BC8A327a5aafb603.json
+++ b/labels/eip155:143/erc20:0x754704Bc059F8C67012fEd69BC8A327a5aafb603.json
@@ -1,6 +1,4 @@
 {
-    "labels": [
-        "stable_coin"
-    ],
+    "labels": [],
     "canonicalHead": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 }

--- a/labels/eip155:324/erc20:0x1d17CBcF0D6D143135aE902365D2E5e2A16538D4.json
+++ b/labels/eip155:324/erc20:0x1d17CBcF0D6D143135aE902365D2E5e2A16538D4.json
@@ -1,6 +1,4 @@
 {
-    "labels": [
-        "stable_coin"
-    ],
+    "labels": [],
     "canonicalHead": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 }

--- a/labels/eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831.json
+++ b/labels/eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831.json
@@ -1,6 +1,4 @@
 {
-    "labels": [
-        "stable_coin"
-    ],
+    "labels": [],
     "canonicalHead": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 }

--- a/labels/eip155:43114/erc20:0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7.json
+++ b/labels/eip155:43114/erc20:0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7.json
@@ -1,0 +1,4 @@
+{
+    "labels": [],
+    "canonicalHead": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7"
+}

--- a/labels/eip155:43114/erc20:0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E.json
+++ b/labels/eip155:43114/erc20:0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E.json
@@ -1,6 +1,4 @@
 {
-    "labels": [
-        "stable_coin"
-    ],
+    "labels": [],
     "canonicalHead": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 }

--- a/labels/eip155:59144/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA.json
+++ b/labels/eip155:59144/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA.json
@@ -1,0 +1,4 @@
+{
+    "labels": [],
+    "canonicalHead": "eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA"
+}

--- a/labels/eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913.json
+++ b/labels/eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913.json
@@ -1,6 +1,4 @@
 {
-    "labels": [
-        "stable_coin"
-    ],
+    "labels": [],
     "canonicalHead": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 }

--- a/labels/eip155:999/erc20:0xb88339CB7199b77E23DB6E890353E22632Ba630f.json
+++ b/labels/eip155:999/erc20:0xb88339CB7199b77E23DB6E890353E22632Ba630f.json
@@ -1,6 +1,4 @@
 {
-    "labels": [
-        "stable_coin"
-    ],
+    "labels": [],
     "canonicalHead": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 }

--- a/labels/solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.json
+++ b/labels/solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.json
@@ -1,0 +1,4 @@
+{
+    "labels": [],
+    "canonicalHead": "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+}

--- a/labels/solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB.json
+++ b/labels/solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB.json
@@ -1,0 +1,4 @@
+{
+    "labels": [],
+    "canonicalHead": "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7"
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,5 @@
     "ethereumjs-util": "^5.1.1",
     "tape": "^4.6.3",
     "zod": "^4.3.6"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "ethereumjs-util": "^5.1.1",
     "tape": "^4.6.3",
     "zod": "^4.3.6"
+  },
+  "dependencies": {
+    "ethereum-cryptography": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,5 @@
     "tape": "^4.6.3",
     "zod": "^4.3.6"
   },
-  "dependencies": {
-    "ethereum-cryptography": "^3.2.0"
-  }
+  "dependencies": {}
 }

--- a/scripts/seed-canonical-heads.mjs
+++ b/scripts/seed-canonical-heads.mjs
@@ -73,7 +73,7 @@ function writeLabelFile(filePath, data) {
     fs.mkdirSync(dir, { recursive: true });
   }
 
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 4) + "\n");
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n");
 }
 
 function platformToCaip19(platform, address) {

--- a/scripts/seed-canonical-heads.mjs
+++ b/scripts/seed-canonical-heads.mjs
@@ -4,17 +4,23 @@ import { toChecksumAddress } from "ethereumjs-util";
 
 const LABELS_DIR = path.resolve(import.meta.dirname, "../labels");
 
-const PLATFORM_TO_CAIP2 = {
-  ethereum: "eip155:1",
-  "polygon-pos": "eip155:137",
-  "binance-smart-chain": "eip155:56",
-  linea: "eip155:59144",
-  base: "eip155:8453",
-  "optimistic-ethereum": "eip155:10",
-  "arbitrum-one": "eip155:42161",
-  scroll: "eip155:534352",
-  monad: "eip155:143",
-  hyperevm: "eip155:999",
+const PLATFORM_MAP = {
+  ethereum: { caip2: "eip155:1", assetNamespace: "erc20" },
+  "polygon-pos": { caip2: "eip155:137", assetNamespace: "erc20" },
+  "binance-smart-chain": { caip2: "eip155:56", assetNamespace: "erc20" },
+  linea: { caip2: "eip155:59144", assetNamespace: "erc20" },
+  base: { caip2: "eip155:8453", assetNamespace: "erc20" },
+  "optimistic-ethereum": { caip2: "eip155:10", assetNamespace: "erc20" },
+  "arbitrum-one": { caip2: "eip155:42161", assetNamespace: "erc20" },
+  scroll: { caip2: "eip155:534352", assetNamespace: "erc20" },
+  monad: { caip2: "eip155:143", assetNamespace: "erc20" },
+  hyperevm: { caip2: "eip155:999", assetNamespace: "erc20" },
+  avalanche: { caip2: "eip155:43114", assetNamespace: "erc20" },
+  zksync: { caip2: "eip155:324", assetNamespace: "erc20" },
+  solana: {
+    caip2: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    assetNamespace: "token",
+  },
 };
 
 const CANONICAL_HEAD_GROUPS = [
@@ -45,7 +51,9 @@ const CANONICAL_HEAD_GROUPS = [
 ];
 
 function caip19ToFilePath(caip19) {
-  const [chain, asset] = caip19.split("/");
+  const slashIndex = caip19.lastIndexOf("/");
+  const chain = caip19.substring(0, slashIndex);
+  const asset = caip19.substring(slashIndex + 1);
 
   return path.join(LABELS_DIR, chain, `${asset}.json`);
 }
@@ -69,13 +77,16 @@ function writeLabelFile(filePath, data) {
 }
 
 function platformToCaip19(platform, address) {
-  const caip2 = PLATFORM_TO_CAIP2[platform];
+  const mapping = PLATFORM_MAP[platform];
+  if (!mapping) {
+    return null;
+  }
 
-  if (!caip2) return null;
+  if (mapping.assetNamespace === "erc20") {
+    return `${mapping.caip2}/${mapping.assetNamespace}:${toChecksumAddress(address)}`;
+  }
 
-  const checksummed = toChecksumAddress(address);
-
-  return `${caip2}/erc20:${checksummed}`;
+  return `${mapping.caip2}/${mapping.assetNamespace}:${address}`;
 }
 
 async function fetchCoinGeckoList() {
@@ -84,7 +95,7 @@ async function fetchCoinGeckoList() {
   );
 
   if (!res.ok) {
-    throw new Error(`CoinGecko error: ${res.status}`);
+    throw new Error(`CoinGecko API error: ${res.status}`);
   }
 
   return res.json();
@@ -92,7 +103,6 @@ async function fetchCoinGeckoList() {
 
 async function seed() {
   console.log("Fetching CoinGecko coin list...\n");
-
   const coinList = await fetchCoinGeckoList();
 
   const coinById = new Map(coinList.map((c) => [c.id, c]));

--- a/scripts/seed-canonical-heads.mjs
+++ b/scripts/seed-canonical-heads.mjs
@@ -1,7 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import { keccak256 } from "ethereum-cryptography/keccak.js";
-import { utf8ToBytes, bytesToHex } from "ethereum-cryptography/utils.js";
 
 const LABELS_DIR = path.resolve(import.meta.dirname, "../labels");
 
@@ -47,7 +45,7 @@ const CANONICAL_HEAD_GROUPS = [
 
 function toChecksumAddress(address) {
   const addr = address.toLowerCase().replace("0x", "");
-  const hash = bytesToHex(keccak256(utf8ToBytes(addr)));
+  const hash = createHash("sha3-256").update(addr).digest("hex");
 
   let checksummed = "0x";
 

--- a/scripts/seed-canonical-heads.mjs
+++ b/scripts/seed-canonical-heads.mjs
@@ -1,0 +1,188 @@
+import fs from "node:fs";
+import path from "node:path";
+import { keccak256 } from "ethereum-cryptography/keccak.js";
+import { utf8ToBytes, bytesToHex } from "ethereum-cryptography/utils.js";
+
+const LABELS_DIR = path.resolve(import.meta.dirname, "../labels");
+
+const PLATFORM_TO_CAIP2 = {
+  ethereum: "eip155:1",
+  "polygon-pos": "eip155:137",
+  "binance-smart-chain": "eip155:56",
+  linea: "eip155:59144",
+  base: "eip155:8453",
+  "optimistic-ethereum": "eip155:10",
+  "arbitrum-one": "eip155:42161",
+  scroll: "eip155:534352",
+  monad: "eip155:143",
+  hyperevm: "eip155:999",
+};
+
+const CANONICAL_HEAD_GROUPS = [
+  {
+    coingeckoId: "ethereum",
+    headCaip19: "eip155:1/slip44:60",
+  },
+  {
+    coingeckoId: "weth",
+    headCaip19: "eip155:1/slip44:60",
+  },
+  {
+    coingeckoId: "usd-coin",
+    headCaip19: "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  },
+  {
+    coingeckoId: "tether",
+    headCaip19: "eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7",
+  },
+  {
+    coingeckoId: "binancecoin",
+    headCaip19: "eip155:56/slip44:714",
+  },
+  {
+    coingeckoId: "metamask-usd",
+    headCaip19: "eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA",
+  },
+];
+
+function toChecksumAddress(address) {
+  const addr = address.toLowerCase().replace("0x", "");
+  const hash = bytesToHex(keccak256(utf8ToBytes(addr)));
+
+  let checksummed = "0x";
+
+  for (let i = 0; i < addr.length; i++) {
+    if (parseInt(hash[i], 16) >= 8) {
+      checksummed += addr[i].toUpperCase();
+    } else {
+      checksummed += addr[i];
+    }
+  }
+
+  return checksummed;
+}
+
+function caip19ToFilePath(caip19) {
+  const [chain, asset] = caip19.split("/");
+
+  return path.join(LABELS_DIR, chain, `${asset}.json`);
+}
+
+function readOrCreateLabelFile(filePath) {
+  if (fs.existsSync(filePath)) {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  }
+
+  return { labels: [] };
+}
+
+function writeLabelFile(filePath, data) {
+  const dir = path.dirname(filePath);
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 4) + "\n");
+}
+
+function platformToCaip19(platform, address) {
+  const caip2 = PLATFORM_TO_CAIP2[platform];
+
+  if (!caip2) return null;
+
+  const checksummed = toChecksumAddress(address);
+
+  return `${caip2}/erc20:${checksummed}`;
+}
+
+async function fetchCoinGeckoList() {
+  const res = await fetch(
+    "https://api.coingecko.com/api/v3/coins/list?include_platform=true",
+  );
+
+  if (!res.ok) {
+    throw new Error(`CoinGecko error: ${res.status}`);
+  }
+
+  return res.json();
+}
+
+async function seed() {
+  console.log("Fetching CoinGecko coin list...\n");
+
+  const coinList = await fetchCoinGeckoList();
+
+  const coinById = new Map(coinList.map((c) => [c.id, c]));
+
+  const summary = [];
+
+  for (const group of CANONICAL_HEAD_GROUPS) {
+    const coin = coinById.get(group.coingeckoId);
+
+    if (!coin) {
+      console.warn(
+        `⚠ CoinGecko ID "${group.coingeckoId}" not found — skipping`,
+      );
+
+      continue;
+    }
+
+    console.log(`Processing: ${group.coingeckoId} → head: ${group.headCaip19}`);
+
+    for (const [platform, address] of Object.entries(coin.platforms)) {
+      if (!address) continue;
+
+      const memberCaip19 = platformToCaip19(platform, address);
+
+      if (!memberCaip19) continue;
+
+      if (memberCaip19 === group.headCaip19) {
+        console.log(`  ✓ ${memberCaip19} (head — skipping)`);
+
+        continue;
+      }
+
+      const filePath = caip19ToFilePath(memberCaip19);
+      const existing = readOrCreateLabelFile(filePath);
+
+      if (existing.canonicalHead === group.headCaip19) {
+        console.log(`  ✓ ${memberCaip19} (already set)`);
+
+        summary.push({
+          member: memberCaip19,
+          head: group.headCaip19,
+          action: "skipped",
+        });
+
+        continue;
+      }
+
+      const action = fs.existsSync(filePath) ? "updated" : "created";
+
+      existing.canonicalHead = group.headCaip19;
+
+      writeLabelFile(filePath, existing);
+
+      console.log(`  + ${memberCaip19} → ${group.headCaip19} (${action})`);
+
+      summary.push({ member: memberCaip19, head: group.headCaip19, action });
+    }
+
+    console.log(" ");
+  }
+
+  console.log("\n=== Summary ===");
+  console.log(`Total processed: ${summary.length}`);
+  console.log(
+    `Created: ${summary.filter((s) => s.action === "created").length}`,
+  );
+  console.log(
+    `Updated: ${summary.filter((s) => s.action === "updated").length}`,
+  );
+  console.log(
+    `Skipped: ${summary.filter((s) => s.action === "skipped").length}`,
+  );
+}
+
+seed().catch(console.error);

--- a/scripts/seed-canonical-heads.mjs
+++ b/scripts/seed-canonical-heads.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { toChecksumAddress } from "ethereumjs-util";
 
 const LABELS_DIR = path.resolve(import.meta.dirname, "../labels");
 
@@ -42,23 +43,6 @@ const CANONICAL_HEAD_GROUPS = [
     headCaip19: "eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA",
   },
 ];
-
-function toChecksumAddress(address) {
-  const addr = address.toLowerCase().replace("0x", "");
-  const hash = createHash("sha3-256").update(addr).digest("hex");
-
-  let checksummed = "0x";
-
-  for (let i = 0; i < addr.length; i++) {
-    if (parseInt(hash[i], 16) >= 8) {
-      checksummed += addr[i].toUpperCase();
-    } else {
-      checksummed += addr[i];
-    }
-  }
-
-  return checksummed;
-}
 
 function caip19ToFilePath(caip19) {
   const [chain, asset] = caip19.split("/");

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,52 @@
   dependencies:
     call-bind "^1.0.8"
 
+"@noble/ciphers@1.3.0":
+  version "1.3.0"
+  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
+
+"@noble/curves@1.9.0":
+  version "1.9.0"
+  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@noble/curves/-/curves-1.9.0.tgz#13e0ca8be4a0ce66c113693a94514e5599f40cfc"
+  integrity sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
+"@noble/curves@~1.9.0":
+  version "1.9.7"
+  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
+  integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
+"@noble/hashes@1.8.0", "@noble/hashes@~1.8.0":
+  version "1.8.0"
+  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
+
+"@scure/base@~1.2.5":
+  version "1.2.6"
+  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+
+"@scure/bip32@1.7.0":
+  version "1.7.0"
+  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
+  integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
+  dependencies:
+    "@noble/curves" "~1.9.0"
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
+
+"@scure/bip39@1.6.0":
+  version "1.6.0"
+  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
+  integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
+  dependencies:
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
+
 "@types/node@*":
   version "25.2.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz#015b7d228470c1dcbfc17fe9c63039d216b4d782"
@@ -418,6 +464,17 @@ ethereum-cryptography@^0.1.3:
     scrypt-js "^3.0.0"
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
+
+ethereum-cryptography@^3.2.0:
+  version "3.2.0"
+  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/ethereum-cryptography/-/ethereum-cryptography-3.2.0.tgz#42a04b57834bf536e552b50a70b9ee5057c71dc6"
+  integrity sha512-Urr5YVsalH+Jo0sYkTkv1MyI9bLYZwW8BENZCeE1QYaTHETEYx0Nv/SVsWkSqpYrzweg6d8KMY1wTjH/1m/BIg==
+  dependencies:
+    "@noble/ciphers" "1.3.0"
+    "@noble/curves" "1.9.0"
+    "@noble/hashes" "1.8.0"
+    "@scure/bip32" "1.7.0"
+    "@scure/bip39" "1.6.0"
 
 ethereumjs-util@^5.1.1:
   version "5.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,52 +16,6 @@
   dependencies:
     call-bind "^1.0.8"
 
-"@noble/ciphers@1.3.0":
-  version "1.3.0"
-  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
-  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
-
-"@noble/curves@1.9.0":
-  version "1.9.0"
-  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@noble/curves/-/curves-1.9.0.tgz#13e0ca8be4a0ce66c113693a94514e5599f40cfc"
-  integrity sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==
-  dependencies:
-    "@noble/hashes" "1.8.0"
-
-"@noble/curves@~1.9.0":
-  version "1.9.7"
-  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
-  integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
-  dependencies:
-    "@noble/hashes" "1.8.0"
-
-"@noble/hashes@1.8.0", "@noble/hashes@~1.8.0":
-  version "1.8.0"
-  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
-  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
-
-"@scure/base@~1.2.5":
-  version "1.2.6"
-  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
-  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
-
-"@scure/bip32@1.7.0":
-  version "1.7.0"
-  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
-  integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
-  dependencies:
-    "@noble/curves" "~1.9.0"
-    "@noble/hashes" "~1.8.0"
-    "@scure/base" "~1.2.5"
-
-"@scure/bip39@1.6.0":
-  version "1.6.0"
-  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
-  integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
-  dependencies:
-    "@noble/hashes" "~1.8.0"
-    "@scure/base" "~1.2.5"
-
 "@types/node@*":
   version "25.2.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz#015b7d228470c1dcbfc17fe9c63039d216b4d782"
@@ -464,17 +418,6 @@ ethereum-cryptography@^0.1.3:
     scrypt-js "^3.0.0"
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
-
-ethereum-cryptography@^3.2.0:
-  version "3.2.0"
-  resolved "https://consensys.jfrog.io/artifactory/api/npm/npm/ethereum-cryptography/-/ethereum-cryptography-3.2.0.tgz#42a04b57834bf536e552b50a70b9ee5057c71dc6"
-  integrity sha512-Urr5YVsalH+Jo0sYkTkv1MyI9bLYZwW8BENZCeE1QYaTHETEYx0Nv/SVsWkSqpYrzweg6d8KMY1wTjH/1m/BIg==
-  dependencies:
-    "@noble/ciphers" "1.3.0"
-    "@noble/curves" "1.9.0"
-    "@noble/hashes" "1.8.0"
-    "@scure/bip32" "1.7.0"
-    "@scure/bip39" "1.6.0"
 
 ethereumjs-util@^5.1.1:
   version "5.2.1"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a standalone seeding script and new `canonicalHead` fields in label JSON files; changes are data/metadata-focused and don’t affect runtime logic unless downstream consumers rely on these pointers.
> 
> **Overview**
> Adds `scripts/seed-canonical-heads.mjs`, which pulls CoinGecko platform mappings and writes/updates label JSONs to include a `canonicalHead` CAIP-19 pointer (with checksum normalization for EVM addresses).
> 
> Seeds initial `canonicalHead` entries for several cross-chain representations (e.g., USDC, USDT, WETH/ETH, BNB, MetaMask USD) by creating new label files and updating existing ones (including formatting/newline fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a41c5ecf8f196a59d3d9cbd91f587ef89f709cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->