### PR TITLE
Add Wrapped Octra metadata

### DIFF
--- a/icons/eip155:1/erc20:0x4647e1fE715c9e23959022C2416C71867F5a6E80.svg
+++ b/icons/eip155:1/erc20:0x4647e1fE715c9e23959022C2416C71867F5a6E80.svg
@@ -1,0 +1,3 @@
+<svg width="152" height="152" viewBox="0 0 152 152" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="76" cy="76.0002" r="42" stroke="#0000DB" stroke-width="16"/>
+</svg>

--- a/metadata/eip155:1/erc20:0x4647e1fE715c9e23959022C2416C71867F5a6E80.json
+++ b/metadata/eip155:1/erc20:0x4647e1fE715c9e23959022C2416C71867F5a6E80.json
@@ -1,0 +1,7 @@
+{
+  "logo": "./icons/eip155:1/erc20:0x4647e1fE715c9e23959022C2416C71867F5a6E80.svg",
+  "name": "Wrapped Octra",
+  "symbol": "wOCT",
+  "decimals": 6,
+  "erc20": true
+}


### PR DESCRIPTION
Adds metadata and icon for Wrapped Octra (`wOCT`), the Ethereum ERC-20 representation of Octra’s native `OCT`.

Asset:
- Name: Wrapped Octra
- Symbol: wOCT
- Decimals: 6
- CAIP-19: `eip155:1/erc20:0x4647e1fE715c9e23959022C2416C71867F5a6E80`

Official references:
- Contract address: https://docs.octra.org/oct-docs/contract-addresses
- Wrapped OCT docs: https://docs.octra.org/oct-docs/wrapped-oct
- Website: https://octra.org
- GitHub: https://github.com/octra-labs
- Etherscan: https://etherscan.io/address/0x4647e1fE715c9e23959022C2416C71867F5a6E80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new token metadata and an SVG icon only; no runtime logic or security-sensitive code is modified.
> 
> **Overview**
> Adds a new CAIP-19 entry for Wrapped Octra (`wOCT`) on Ethereum mainnet, including `name`, `symbol`, `decimals: 6`, and an `erc20` flag.
> 
> Includes a new SVG logo referenced by the metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44088ec61f2278b54eb3c30aad17c1c637addf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->