### PR TITLE
Add defimarketplus DMTp + smUSD tokens (Arbitrum)

### DIFF
--- a/contract-map.json
+++ b/contract-map.json
@@ -139,6 +139,20 @@
     "symbol": "MATH",
     "decimals": 18
   },
+  "0x07fF8bCe905CB285220e4D96d8443cfCF141af8b": {
+    "name": "defimarketplus SAFE-USD",
+    "logo": "smUSD.svg",
+    "erc20": true,
+    "symbol": "smUSD",
+    "decimals": 12
+  },
+  "0x09fd7e0d021D29106c534Edfb4Ea817AC0ea7F84": {
+    "name": "defimarketplus",
+    "logo": "DMTp.svg",
+    "erc20": true,
+    "symbol": "DMTp",
+    "decimals": 18
+  },
   "0x509A38b7a1cC0dcd83Aa9d06214663D9eC7c7F4a": {
     "name": "Blocksquare Token",
     "logo": "BST.svg",

--- a/images/DMTp.svg
+++ b/images/DMTp.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <rect width="100" height="100" rx="20" fill="#012B22"/>
+  <text x="50" y="62" font-family="Inter, system-ui, -apple-system, sans-serif" font-size="34" font-weight="700" letter-spacing="-1.5" text-anchor="middle" fill="#06D6A0">DMTp</text>
+</svg>

--- a/images/smUSD.svg
+++ b/images/smUSD.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <rect width="100" height="100" rx="20" fill="#06D6A0"/>
+  <text x="50" y="62" font-family="Inter, system-ui, -apple-system, sans-serif" font-size="30" font-weight="700" letter-spacing="-1.2" text-anchor="middle" fill="#012B22">smUSD</text>
+</svg>


### PR DESCRIPTION
Adds metadata entries for the **defimarketplus** protocol on Arbitrum mainnet.

## Tokens

### DMTp — defimarketplus governance/utility token
- **Address (Arbitrum):** [`0x09fd7e0d021D29106c534Edfb4Ea817AC0ea7F84`](https://arbiscan.io/address/0x09fd7e0d021D29106c534Edfb4Ea817AC0ea7F84)
- **Source verified:** [Arbiscan #code](https://arbiscan.io/address/0x09fd7e0d021D29106c534Edfb4Ea817AC0ea7F84#code) ✅
- **Decimals:** 18
- **Type:** ERC-20 + ERC-20Permit
- Mint-on-deposit, **fair launch (no premine, no team allocation)**, governance- + utility token

### smUSD — defimarketplus SAFE-USD vault share
- **Address (Arbitrum):** [`0x07fF8bCe905CB285220e4D96d8443cfCF141af8b`](https://arbiscan.io/address/0x07fF8bCe905CB285220e4D96d8443cfCF141af8b)
- **Source verified:** [Arbiscan #code](https://arbiscan.io/address/0x07fF8bCe905CB285220e4D96d8443cfCF141af8b#code) ✅
- **Decimals:** 12 (USDC 6 + ERC-4626 `_decimalsOffset = 6` for inflation-attack defense)
- **Type:** ERC-4626 share token, UUPS proxy

## Project information

- **Website:** https://dmtp.io
- **How it works:** https://dmtp.io/how-it-works
- **FAQ:** https://dmtp.io/faq
- **Description:** Cross-chain non-custodial yield aggregator for stablecoins. Routes USDC across audited DeFi protocols (Aave V3 etc.) and shares value with depositors via vault PPS appreciation and DMTp supply contraction (treasury-funded buyback-and-burn via CoW Protocol).

## Governance

All admin functions on these contracts are gated by a Gnosis Safe at [`0x7e9e52A5b485b2849daf99fCE6b4fA7C7e1661B8`](https://app.safe.global/home?safe=arb1:0x7e9e52A5b485b2849daf99fCE6b4fA7C7e1661B8) (1-of-2 multisig, growing toward 5-of-N). Hard caps in code on fees (≤0.50% each) and burn share (≤50%) — governance physically cannot exceed these.

## Activity signals

- All 8 protocol contracts source-verified on Arbiscan
- Live deposits + withdrawals already flowing
- Backend indexer running at https://api.dmtp.io/health (returns 200)

## Style guide compliance

- Logos are SVG with solid backgrounds, fit within 80% safe zone, square 100x100 viewBox
- Brand colors: Electric Teal `#06D6A0` foreground, deep dark `#012B22` background
- No raster embeds, no animations, no foreignObject

Happy to amend if anything needs adjusting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds token metadata entries and new SVG logo assets, with no runtime logic changes.
> 
> **Overview**
> Adds two new Arbitrum token entries to `contract-map.json` for defimarketplus: `DMTp` (18 decimals) and `smUSD` (12 decimals), each wired to a new logo asset.
> 
> Includes new `images/DMTp.svg` and `images/smUSD.svg` files for token display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c2c843dfd3d4b7240dc6c4641b1439a42a4f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->