### PR TITLE
ci: add workflow to validate Ondo Tokenized metadata has a label

### DIFF
--- a/.github/workflows/validate-ondo-labels.yml
+++ b/.github/workflows/validate-ondo-labels.yml
@@ -1,0 +1,79 @@
+name: Validate Ondo Tokenized Labels
+
+on:
+  pull_request:
+
+jobs:
+  validate-ondo-labels:
+    name: Validate Ondo Tokenized Labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed metadata files in this PR
+        id: changed
+        run: |
+          # List files added or modified in this PR vs the base branch
+          git diff --name-only --diff-filter=AM origin/${{ github.base_ref }}...HEAD \
+            | grep '^metadata/.*\.json$' > changed_metadata.txt || true
+          echo "Changed metadata files:"
+          cat changed_metadata.txt || echo "(none)"
+
+      - name: Check Ondo Tokenized metadata has a label file
+        run: |
+          set -euo pipefail
+
+          ERRORS=()
+
+          while IFS= read -r file; do
+            [ -f "$file" ] || continue
+
+            if python3 -c "import json,sys; d=json.load(open('$file')); sys.exit(0 if '(Ondo Tokenized' in d.get('name','') else 1)" 2>/dev/null; then
+              # Derive expected label path:
+              # metadata/eip155:1/erc20:0xABC.json -> labels/eip155:1/erc20:0xABC.json
+              label_file="${file/metadata\//labels/}"
+
+              if [ ! -f "$label_file" ]; then
+                ERRORS+=("Missing label file for: $file (expected: $label_file)")
+              else
+                # Confirm labels array is non-empty
+                if ! python3 -c "
+          import json, sys
+          with open('$label_file') as f:
+              data = json.load(f)
+          if not data.get('labels'):
+              sys.exit(1)
+          " 2>/dev/null; then
+                  ERRORS+=("Label file exists but has no labels: $label_file")
+                fi
+              fi
+            fi
+          done < changed_metadata.txt
+
+          if [ ${#ERRORS[@]} -gt 0 ]; then
+            echo ""
+            echo "❌ Validation failed — the following Ondo Tokenized metadata entries are missing a label file:"
+            echo ""
+            for err in "${ERRORS[@]}"; do
+              echo "  • $err"
+            done
+            echo ""
+            echo "Every token whose name contains '(Ondo Tokenized)' must have a corresponding"
+            echo "label file under labels/ with at least one label (e.g. \"ondo\")."
+            echo ""
+            echo "To add a label, run:"
+            echo "  npm run asset:set -- --caip <caip> --labels \"ondo\""
+            exit 1
+          fi
+
+          echo "✅ All Ondo Tokenized metadata entries in this PR have a valid label file."
+
+  all-jobs-pass:
+    name: All jobs pass
+    runs-on: ubuntu-latest
+    needs:
+      - validate-ondo-labels
+    steps:
+      - run: echo "Great success!"

--- a/.github/workflows/validate-ondo-labels.yml
+++ b/.github/workflows/validate-ondo-labels.yml
@@ -30,7 +30,7 @@ jobs:
           while IFS= read -r file; do
             [ -f "$file" ] || continue
 
-            if python3 -c "import json,sys; d=json.load(open('$file')); sys.exit(0 if '(Ondo Tokenized' in d.get('name','') else 1)" 2>/dev/null; then
+            if python3 -c "import json,sys; d=json.load(open('$file')); sys.exit(0 if '(Ondo Tokenized)' in d.get('name','') else 1)" 2>/dev/null; then
               # Derive expected label path:
               # metadata/eip155:1/erc20:0xABC.json -> labels/eip155:1/erc20:0xABC.json
               label_file="${file/metadata\//labels/}"

--- a/.github/workflows/validate-ondo-labels.yml
+++ b/.github/workflows/validate-ondo-labels.yml
@@ -70,10 +70,4 @@ jobs:
 
           echo "✅ All Ondo Tokenized metadata entries in this PR have a valid label file."
 
-  all-jobs-pass:
-    name: All jobs pass
-    runs-on: ubuntu-latest
-    needs:
-      - validate-ondo-labels
-    steps:
-      - run: echo "Great success!"
+


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that validates any PR adding or modifying metadata for Ondo Tokenized tokens includes a corresponding label file.

## Motivation

As Ondo Global Markets tokenized stock/ETF entries are added to this repo, it's important to ensure they are consistently labelled so downstream consumers (e.g. MetaMask swap UI) can correctly identify and filter RWA tokens. Without this check, metadata entries with `(Ondo Tokenized` in the name could be merged without a label, leading to inconsistent data.

## What this workflow does

- Triggers on every pull request
- Identifies metadata files **changed or added in the PR diff** (does not scan the full repo, so pre-existing unlabelled entries are unaffected)
- For each changed metadata file whose `name` contains `(Ondo Tokenized)`, checks that:
  - A corresponding label file exists under `labels/`
  - The label file contains a non-empty `labels` array
- Fails the check with a clear error message and the exact command to fix it:
  ```
  npm run asset:set -- --caip <caip> --labels "ondo"
  ```

## Example failure output

```
❌ Validation failed — the following Ondo Tokenized metadata entries are missing a label file:

  • Missing label file for: metadata/eip155:1/erc20:0xABC.json (expected: labels/eip155:1/erc20:0xABC.json)

Every token whose name contains '(Ondo Tokenized)' must have a corresponding
label file under labels/ with at least one label (e.g. "ondo").
```

## Notes

- Intentionally scoped to PR diff only — a separate PR addresses pre-existing unlabelled Ondo tokens on master
- Works across all chain namespaces (`eip155:1`, `eip155:56`, `solana:*`, etc.) since the `metadata/` → `labels/` path substitution is chain-agnostic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only validation with no runtime or data-path changes; scope is limited to PR diffs.
> 
> **Overview**
> Adds a **pull-request** GitHub Actions job that enforces label coverage for newly changed Ondo RWA metadata.
> 
> On each PR it collects **added or modified** `metadata/**/*.json` files (vs the base branch), and for any whose `name` contains `(Ondo Tokenized)` it requires a parallel file under `labels/` (same path with `metadata/` swapped) with a **non-empty** `labels` array. Failures print actionable guidance, including `npm run asset:set -- --caip <caip> --labels "ondo"`. Pre-existing unlabelled tokens on the default branch are **not** scanned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25db38218ab45f462be3f8260bc700a9de9a0b3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->