### PR TITLE
Add Tethelephant USDT.e token metadata

### DIFF
--- a/images/USDT_e.svg
+++ b/images/USDT_e.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" role="img" aria-label="Tethelephant logo">
+  <circle cx="128" cy="128" r="128" fill="#26A17B"/>
+  <rect x="64" y="52" width="128" height="32" fill="#FFFFFF"/>
+  <rect x="112" y="68" width="32" height="136" fill="#FFFFFF"/>
+  <ellipse cx="128" cy="128" rx="84" ry="18.8" fill="none" stroke="#FFFFFF" stroke-width="10"/>
+</svg>


### PR DESCRIPTION
Add Tethelephant (USDT.e) token metadata and logo.

Network: BNB Smart Chain
Contract: 0xc15979980D74ee0085c53a4AaC974237921eA7cA
Symbol: USDT.e
Decimals: 18
Website: https://tethelephant.xyz
BscScan: https://bscscan.com/token/0xc15979980D74ee0085c53a4AaC974237921eA7cA

USDT.e is a meme token and is not affiliated with Tether Limited, official USDT, Bitfinex, or any related company.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static image-only change with no runtime or security impact; reviewers should confirm metadata JSON/icon paths are added separately if required for the registry.
> 
> **Overview**
> Adds a new **`images/USDT_e.svg`** asset: a green-circle “Tethelephant” mark (USDT-style T with horizontal band) labeled for accessibility as the Tethelephant logo.
> 
> Per the PR description, this supports listing **Tethelephant (USDT.e)** on **BNB Smart Chain** (`0xc15979980D74ee0085c53a4AaC974237921eA7cA`, 18 decimals); the provided diff only includes the logo file, not a `metadata/eip155:56/erc20:…` JSON entry like other BSC tokens use under `icons/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 695563e4f6cc363cad4627ac900e4fbdb764b77e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->