### PR TITLE
feat: native name robinhood

### DIFF
--- a/metadata/eip155:4663/slip44:60.json
+++ b/metadata/eip155:4663/slip44:60.json
@@ -1,5 +1,5 @@
 {
-  "name": "ETH",
+  "name": "Ethereum",
   "symbol": "ETH",
   "decimals": 18,
   "erc20": false,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-field metadata label change with no logic, contract, or symbol changes.
> 
> **Overview**
> Updates the **native token** metadata for **eip155:4663** (Robinhood) so the `name` field reads **Ethereum** instead of **ETH**, while `symbol`, decimals, and logo stay the same.
> 
> This is a display-label change only for consumers that show the full asset name from `slip44:60.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bdc47fd91be557a99825ae0ffa99218193502fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->