### PR TITLE
docs: agent instruction files teach npm, but the repo runs on yarn

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -9,8 +9,8 @@
 This repository uses a CLI tool for managing CAIP-19 contract metadata and icons.
 
 **Main commands:**
-- `npm run asset:set` - Add or update an asset
-- `npm run asset:verify` - Verify asset files
-- `npm run asset:list` - List assets in a namespace
+- `yarn asset:set` - Add or update an asset
+- `yarn asset:verify` - Verify asset files
+- `yarn asset:list` - List assets in a namespace
 
 For detailed usage, parameters, examples, and workflow, refer to the canonical documentation in `.github/copilot-instructions.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,8 @@
 
 This repository uses a CLI tool (`cli-update-asset.js`) to manage contract metadata and icons following the CAIP-19 standard.
 
+Install dependencies first with `yarn` (the repo pins them via `yarn.lock`, which is what CI installs from).
+
 ### Available Commands
 
 #### 1. Add or Update an Asset
@@ -12,7 +14,7 @@ Use the `set` command to add a new asset or update an existing one:
 
 ```bash
 # Add a new asset with all required fields
-npm run asset:set -- \
+yarn asset:set \
   --caip "eip155:1/erc20:0xTOKEN_ADDRESS" \
   --name "Token Name" \
   --symbol "SYMBOL" \
@@ -20,12 +22,12 @@ npm run asset:set -- \
   --image ./path/to/logo.svg
 
 # Add or update labels for an asset
-npm run asset:set -- \
+yarn asset:set \
   --caip "eip155:1/erc20:0xTOKEN_ADDRESS" \
   --labels "stable_coin,blue_chip"
 
 # Or use a direct URL for the image
-npm run asset:set -- \
+yarn asset:set \
   --caip "eip155:1/erc20:0xTOKEN_ADDRESS" \
   --name "Token Name" \
   --symbol "SYMBOL" \
@@ -33,12 +35,12 @@ npm run asset:set -- \
   --image "https://example.com/logo.png"
 
 # Update only specific fields of an existing asset
-npm run asset:set -- \
+yarn asset:set \
   --caip "eip155:1/erc20:0xTOKEN_ADDRESS" \
   --name "Updated Token Name"
 
 # Update just the image
-npm run asset:set -- \
+yarn asset:set \
   --caip "eip155:1/erc20:0xTOKEN_ADDRESS" \
   --image ./new-logo.svg
 ```
@@ -67,7 +69,7 @@ npm run asset:set -- \
 Check if an asset's metadata and icon files are valid:
 
 ```bash
-npm run asset:verify -- \
+yarn asset:verify \
   --caip "eip155:1/erc20:0xTOKEN_ADDRESS"
 ```
 
@@ -77,16 +79,16 @@ List all assets in a specific namespace:
 
 ```bash
 # List all Ethereum Mainnet assets
-npm run asset:list -- --namespace "eip155:1"
+yarn asset:list --namespace "eip155:1"
 
 # List all Polygon assets
-npm run asset:list -- --namespace "eip155:137"
+yarn asset:list --namespace "eip155:137"
 ```
 
 ### Workflow
 
-1. **Add or update** an asset using `npm run asset:set`
-2. **Verify** the changes using `npm run asset:verify`
+1. **Add or update** an asset using `yarn asset:set`
+2. **Verify** the changes using `yarn asset:verify`
 3. **Rebuild** the contract-map.json: `node buildindex.js`
 4. **Review** the changes in git
 5. **Commit and push** your changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@
 This repository uses a CLI tool for managing CAIP-19 contract metadata and icons.
 
 **Main commands:**
-- `npm run asset:set` - Add or update an asset
-- `npm run asset:verify` - Verify asset files
-- `npm run asset:list` - List assets in a namespace
+- `yarn asset:set` - Add or update an asset
+- `yarn asset:verify` - Verify asset files
+- `yarn asset:list` - List assets in a namespace
 
 For detailed usage, parameters, examples, and workflow, refer to the canonical documentation in `.github/copilot-instructions.md`.


### PR DESCRIPTION
## What

The three agent-instruction files — `.cursorrules`, `CLAUDE.md`, and the canonical `.github/copilot-instructions.md` they both point to — all teach `npm run asset:set` / `asset:verify` / `asset:list`. The repo itself runs on yarn: the only committed lockfile is `yarn.lock`, and CI (`.github/workflows/test.yml`) installs with `yarn --frozen-lockfile`. All three files were introduced together in #1711 with the npm-flavored commands, so this is one shared bug across the set, not drift between them.

**Why it matters in practice:** the docs contain no install/bootstrap step at all, so an AI agent (or contributor) that needs `asset:set` to work will infer `npm install` from the command style — which bypasses `yarn.lock`'s pinned resolutions and drops a stray `package-lock.json` in the tree, diverging from exactly what CI enforces.

## Changes

- `.github/copilot-instructions.md` — all 10 `npm run asset:X` occurrences → `yarn asset:X` (the `--` separators dropped; yarn passes script args through directly), plus a one-line bootstrap note: install with `yarn`, since that's what `yarn.lock`/CI pin.
- `.cursorrules` and `CLAUDE.md` — the same three quick-reference lines each, applied identically so the two files stay byte-for-byte twins (title line aside), preserving the existing pointer-stub design.

Docs-only; no code touched. Verified `yarn asset:set` / `asset:list` arg-forwarding against the plain `node cli-update-asset.js` scripts in `package.json`.

**Full disclosure:** found while validating [ai-harness-doctor](https://github.com/NieZhuZhu/ai-harness-doctor), a docs-vs-lockfile drift linter we maintain — that's how this repo ended up in our scan sample. Everything above is verifiable directly from `yarn.lock` + `test.yml`, no tool needed. For measured impact of this defect class (agent docs teaching a package manager the lockfile contradicts) on another repo: [benchmark & methodology](https://github.com/NieZhuZhu/ai-harness-doctor/tree/main/benchmark/corpus/evals/comp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to CLI examples and install guidance; no runtime or CI behavior changes.
> 
> **Overview**
> **Agent and contributor docs now match how this repo actually installs and runs the asset CLI** — `yarn` + `yarn.lock`/CI, not `npm run`.
> 
> The canonical `.github/copilot-instructions.md` replaces every `npm run asset:*` example with `yarn asset:*` (dropping the npm `--` arg separator) and adds a short note to bootstrap with `yarn` first. The `.cursorrules` and `CLAUDE.md` quick-reference stubs get the same three command lines so they stay in sync with that doc.
> 
> Docs-only; no application or script code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70b407b05fb90fc38d6af9c1bbd10124bf6a3329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->