### PR TITLE
Add arsh token

### DIFF
--- a/metadata/eip155:56/erc20:0x0ebD506eA11Ac1d6DBDbf80651aF22202b94F954.json
+++ b/metadata/eip155:56/erc20:0x0ebD506eA11Ac1d6DBDbf80651aF22202b94F954.json
@@ -1,0 +1,7 @@
+{
+    "name": "ARSH COIN",
+    "symbol": "AR$H",
+    "decimals": 18,
+    "erc20": true,
+    "logo": "./icons/eip155:56/erc20:0x0ebD506eA11Ac1d6DBDbf80651aF22202b94F954.svg"
+}


### PR DESCRIPTION
## Summary

This PR adds metadata and the logo for the ARSH COIN (AR$H) BEP-20 token on BNB Smart Chain.

### Token Details

- Name: ARSH COIN
- Symbol: AR$H
- Chain: BNB Smart Chain (Chain ID: 56)
- Contract: 0x0ebD506eA11Ac1d6DBDbf80651aF22202b94F954

### Files Added

- icons/eip155:56/erc20:0x0ebD506eA11Ac1d6DBDbf80651aF22202b94F954.svg
- metadata/eip155:56/erc20:0x0ebD506eA11Ac1d6DBDbf80651aF22202b94F954.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive token-list metadata and static icon only; no application or contract logic changes.
> 
> **Overview**
> Registers **ARSH COIN** (**AR$H**) as a BEP-20 token on BNB Smart Chain (chain ID 56) at contract `0x0ebD506eA11Ac1d6DBDbf80651aF22202b94F954`.
> 
> Adds the usual pair of assets: a metadata JSON entry (name, symbol, 18 decimals, `erc20: true`, logo path) and an SVG icon with an embedded PNG for wallet/token lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9db82113de0dcda607c2d7f169d6e433564fe18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->