### PR TITLE
fix: USDB decimals on XDC

### DIFF
--- a/metadata/eip155:50/erc20:0xA23885c8E0743C734Bd6Da0df66e2631Ee9Bc6D8.json
+++ b/metadata/eip155:50/erc20:0xA23885c8E0743C734Bd6Da0df66e2631Ee9Bc6D8.json
@@ -1,7 +1,7 @@
 {
   "name": "USDB",
   "symbol": "USDB",
-  "decimals": 18,
+  "decimals": 6,
   "erc20": true,
   "logo": "./icons/eip155:50/erc20:0xA23885c8E0743C734Bd6Da0df66e2631Ee9Bc6D8.png"
 }


### PR DESCRIPTION
## Summary

Corrects the XDC USDB token metadata for `0xA23885c8E0743C734Bd6Da0df66e2631Ee9Bc6D8` from 18 decimals to 6.

## Why

The stored decimal precision was incorrect, which can cause consumers to display USDB balances with the wrong scale.

## Validation

- `npm run asset:verify -- --caip 'eip155:50/erc20:0xA23885c8E0743C734Bd6Da0df66e2631Ee9Bc6D8'`
- `yarn test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field metadata correction with no application logic changes; wrong decimals in production would have been the higher-risk state.
> 
> **Overview**
> Updates **USDB** token metadata on XDC (`eip155:50`, `0xA23885c8E0743C734Bd6Da0df66e2631Ee9Bc6D8`) so **`decimals`** is **6** instead of **18**, matching on-chain precision and aligning with other 6-decimal stablecoins on the same chain.
> 
> This fixes incorrect balance scaling for any consumer that reads decimals from this metadata file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2652013b58fe376d8ab4be728432a7a811ef2ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->