### PR TITLE
Add CUBIT token metadata and icon

### DIFF
--- a/icons/eip155:1/erc20:0x2524592CfD16eAb328eE54636259b43a48154A8D.svg
+++ b/icons/eip155:1/erc20:0x2524592CfD16eAb328eE54636259b43a48154A8D.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#071B2D"/>
+  <path d="M380 140 A170 170 0 1 0 380 372" fill="none" stroke="#006A9E" stroke-width="66" stroke-linecap="round"/>
+  <path d="M380 140 A170 170 0 1 0 380 372" fill="none" stroke="#D9E7EE" stroke-width="54" stroke-linecap="round"/>
+  <path d="M380 140 A170 170 0 1 0 380 372" fill="none" stroke="#8FAABB" stroke-width="42" stroke-linecap="round"/>
+  <path d="M380 140 A170 170 0 1 0 380 372" fill="none" stroke="#00BFE7" stroke-width="28" stroke-linecap="round"/>
+  <path d="M380 140 A170 170 0 1 0 380 372" fill="none" stroke="#0078AE" stroke-width="14" stroke-linecap="round"/>
+</svg>

--- a/metadata/eip155:1/erc20:0x2524592CfD16eAb328eE54636259b43a48154A8D.json
+++ b/metadata/eip155:1/erc20:0x2524592CfD16eAb328eE54636259b43a48154A8D.json
@@ -3,5 +3,5 @@
   "symbol": "CUBIT",
   "decimals": 8,
   "erc20": true,
-  "logo": "./icons/eip155:1/erc20:0x2524592CfD16eAb328eE54636259b43a48154A8D.png"
+  "logo": "./icons/eip155:1/erc20:0x2524592CfD16eAb328eE54636259b43a48154A8D.svg"
 }

--- a/metadata/eip155:1/erc20:0x2524592CfD16eAb328eE54636259b43a48154A8D.json
+++ b/metadata/eip155:1/erc20:0x2524592CfD16eAb328eE54636259b43a48154A8D.json
@@ -1,0 +1,7 @@
+{
+  "name": "CUBIT",
+  "symbol": "CUBIT",
+  "decimals": 8,
+  "erc20": true,
+  "logo": "./icons/eip155:1/erc20:0x2524592CfD16eAb328eE54636259b43a48154A8D.png"
+}


### PR DESCRIPTION
Adds metadata and icon for CUBIT on Ethereum Mainnet.

- Network: Ethereum Mainnet (eip155:1)
- Token standard: ERC-20
- Token name: CUBIT
- Symbol: CUBIT
- Decimals: 8
- Contract: 0x2524592CfD16eAb328eE54636259b43a48154A8D
- Official project website: https://www.cubit.im/
- Official CUBIT project page: https://www.cubit.im/cubitcoin
- Etherscan token page: https://etherscan.io/token/0x2524592cfd16eab328ee54636259b43a48154a8d

The official project website has been updated to display the CUBIT Ethereum Mainnet contract address. The project site also documents the CUBIT ecosystem and ERC-20 deployment.

This PR adds a pure SVG vector icon following the repository icon style guidance and metadata pointing to the matching CAIP-19 icon path.

On-chain values used in the metadata:
- name(): CUBIT
- symbol(): CUBIT
- decimals(): 8

Please let us know if any additional verification or formatting changes are required.