### PR TITLE
Add USDTz (USDTZ) token metadata and logo

### DIFF
--- a/icons/eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892.svg
+++ b/icons/eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="16" fill="#26A17B"/>
+  <circle cx="16" cy="16" r="13.5" fill="none" stroke="#FFFFFF" stroke-width="1.5"/>
+  <text x="16" y="18.5"
+        text-anchor="middle"
+        font-family="Arial, sans-serif"
+        font-size="7"
+        font-weight="700"
+        fill="#FFFFFF">USDTz</text>
+</svg>

--- a/metadata/eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892.json
+++ b/metadata/eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892.json
@@ -1,0 +1,9 @@
+{
+  "eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892": {
+    "name": "USDTz",
+    "symbol": "USDTZ",
+    "decimals": 6,
+    "erc20": true,
+    "logo": "./icons/eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892.png"
+  }
+}

--- a/metadata/eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892.json
+++ b/metadata/eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892.json
@@ -1,9 +1,7 @@
 {
-  "eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892": {
-    "name": "USDTz",
-    "symbol": "USDTZ",
-    "decimals": 6,
-    "erc20": true,
-    "logo": "./icons/eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892.png"
-  }
+  "name": "USDTz",
+  "symbol": "USDTZ",
+  "decimals": 6,
+  "erc20": true,
+  "logo": "./icons/eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892.svg"
 }


### PR DESCRIPTION
## Token information

Name: USDTz
Symbol: USDTZ
Network: Ethereum Mainnet
Chain ID: 1
Contract: 0xB79aba668859704b30988aAB84AeB88F0467D892
Decimals: 6

## Changes

- Added USDTz ERC-20 metadata
- Added USDTz SVG token icon
- Added metadata reference to the SVG icon

Project website:
https://krisztofer330.github.io/usdtz-project/

Contract:
https://etherscan.io/address/0xB79aba668859704b30988aAB84AeB88F0467D892

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive token metadata and icon only; no application or contract logic changes.
> 
> **Overview**
> Registers **USDTz** (`USDTZ`, 6 decimals) for Ethereum mainnet at `0xB79aba668859704b30988aAB84AeB88F0467D892`.
> 
> Adds the usual pair of assets: `metadata/eip155:1/erc20:0xB79aba668859704b30988aAB84AeB88F0467D892.json` (name, symbol, decimals, `erc20`, logo path) and a new 32×32 SVG icon labeled “USDTz” with a green circular background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ad8aa59f4f7c6205ef6ef1aa639d435fe2b38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->