### PR TITLE
Add GTAF token metadata

### DIFF
--- a/metadata/eip155:56/erc20:0x190a79d19be3259ba4df59847bb27948aba2bca0.json
+++ b/metadata/eip155:56/erc20:0x190a79d19be3259ba4df59847bb27948aba2bca0.json
@@ -1,0 +1,7 @@
+{
+  "name": "Green Tech Agro Farms",
+  "symbol": "GTAF",
+  "decimals": 18,
+  "erc20": true,
+  "logo": "./icons/eip155:56/erc20:0x190a79d19be3259ba4df59847bb27948aba2bca0.svg"
+}


### PR DESCRIPTION
This pull request adds metadata for the GTAF ERC-20 token on BNB Smart Chain (BSC).

Token name: Green Tech Agro Farms
Symbol: GTAF
Network: BNB Smart Chain
Contract address: 0x190a79d19be3259ba4df59847bb27948aba2bca0

Official website: www.gtaf.net

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only metadata addition with no application or security logic changes.
> 
> **Overview**
> Adds **GTAF** (*Green Tech Agro Farms*) to the token registry for **BNB Smart Chain** (`eip155:56`) at contract `0x190a79d19be3259ba4df59847bb27948aba2bca0`.
> 
> The new metadata entry follows the usual ERC-20 shape: name, symbol, 18 decimals, `erc20: true`, and a logo path under `./icons/eip155:56/erc20:…`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b42ffbbabf22210658067406fd0f3db72f5567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->