### PR TITLE
Add metadata for MyUSDT (MUSDT)

### DIFF
--- a/contract-metadata.json
+++ b/contract-metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "MyUSDT",
+  "symbol": "MUSDT",
+  "address": "TPHjxcwuDiAJtnySMo99ou7Rbqo8cqVhsh",
+  "decimals": 6,
+  "logo": "https://i.ibb.co/s9HhX5jP/file-00000000b53482468cb1a919f5cc14ff.png",
+  "website": "https://github.com/nassicatbessir-cell/justlists",
+  "description": "A custom TRC20 token for testing and demonstration purposes."
+}


### PR DESCRIPTION
### 📑 Token Metadata Submission

- **Token Name:** MyUSDT
- **Symbol:** MUSDT
- **Contract Address:** `TPHjxcwuDiAJtnySMo99ou7Rbqo8cqVhsh`
- **Decimals:** 6
- **Network:** TRON Mainnet (TRC-20)
- **Logo URI:** https://i.ibb.co/s9HhX5jP/file-00000000b53482468cb1a919f5cc14ff.png

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds static JSON only with no application or contract logic changes; review should still confirm the token listing policy (e.g. name similarity to USDT).
> 
> **Overview**
> Introduces a new root **`contract-metadata.json`** describing the TRC-20 token **MyUSDT (MUSDT)** at `TPHjxcwuDiAJtnySMo99ou7Rbqo8cqVhsh`, including 6 decimals, logo URL, project website, and a short description for testing/demo.
> 
> This is a metadata-only addition; no updates to the usual **`contract-map.json`** / CAIP-19 asset entries or bundled logo assets appear in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98102cc4c6a4f2571fa221d574a6e1f4e5fd7e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->