### PR TITLE
chore: shorten tokenlist CDN cache and invalidate it after upload

### DIFF
--- a/.github/workflows/update-caip-map.yml
+++ b/.github/workflows/update-caip-map.yml
@@ -40,5 +40,16 @@ jobs:
       - name: Upload to S3
         run: |
           echo "Uploading tokenlist to S3..."
-          aws s3 cp metamask-uniswap-tokenlist.json s3://${{ env.S3_BUCKET_NAME }}/${{ env.S3_PATH }} --cache-control "max-age=3600"
+          aws s3 cp metamask-uniswap-tokenlist.json s3://${{ env.S3_BUCKET_NAME }}/${{ env.S3_PATH }} --cache-control "max-age=300"
           echo "Upload complete"
+
+      # Downstream syncs (tokens api) poll this file every 20 minutes; without an
+      # invalidation a merged token only reaches them once the CDN copy expires.
+      # Requires the STATIC_CF_DISTRIBUTION_ID repository variable and
+      # cloudfront:CreateInvalidation on the S3 role; skipped until both exist.
+      - name: Invalidate CDN cache
+        if: ${{ vars.STATIC_CF_DISTRIBUTION_ID != '' }}
+        run: |
+          echo "Invalidating /${{ env.S3_PATH }} on distribution ${{ vars.STATIC_CF_DISTRIBUTION_ID }}..."
+          aws cloudfront create-invalidation --distribution-id "${{ vars.STATIC_CF_DISTRIBUTION_ID }}" --paths "/${{ env.S3_PATH }}"
+          echo "Invalidation requested"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change to cache headers and an optional CloudFront invalidation; no application auth or data-path changes, though enabling the step requires correct IAM and repo vars to avoid failed runs.
> 
> **Overview**
> Updates the **Generate Uniswap Token List** workflow so fresh token merges reach downstream consumers (e.g. tokens API polling every ~20 minutes) sooner.
> 
> The S3 upload now sets **`Cache-Control: max-age=300`** (was **3600**), shortening how long the CDN may serve a stale copy without an explicit purge.
> 
> A new **Invalidate CDN cache** step runs **`aws cloudfront create-invalidation`** for **`/${{ env.S3_PATH }}`** when the repo variable **`STATIC_CF_DISTRIBUTION_ID`** is set; otherwise it is skipped until that variable and **`cloudfront:CreateInvalidation`** on the S3 role are configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0724336f6b46a9deef10bd43740323d394465690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->