### PR TITLE
Add 1inch token icon and metadata for BNB Chain (eip155:56)

### DIFF
--- a/icons/eip155:56/erc20:0x111111111117dC0aa78b770fA6A738034120C302.svg
+++ b/icons/eip155:56/erc20:0x111111111117dC0aa78b770fA6A738034120C302.svg
@@ -1,0 +1,1 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill="#fff" d="M0 0h512v512H0z"/><path d="M436 76H76v360h360z" fill="#000"/></svg>

--- a/metadata/eip155:56/erc20:0x111111111117dC0aa78b770fA6A738034120C302.json
+++ b/metadata/eip155:56/erc20:0x111111111117dC0aa78b770fA6A738034120C302.json
@@ -1,0 +1,7 @@
+{
+  "logo": "./icons/eip155:56/erc20:0x111111111117dC0aa78b770fA6A738034120C302.svg",
+  "name": "1INCH Token",
+  "symbol": "1INCH",
+  "decimals": 18,
+  "erc20": true
+}


### PR DESCRIPTION
Adds token metadata and icon for the 1INCH token on BNB Chain (`eip155:56`), mirroring the existing mainnet entry.

- Same canonical deployment address as Ethereum mainnet: https://bscscan.com/token/0x111111111117dc0aa78b770fa6a738034120c302
- Icon is byte-identical to the current `eip155:1` icon (updated in #1606); name, symbol, and decimals mirror the mainnet metadata (`1INCH Token` / `1INCH` / 18)
- Official project website: https://1inch.com/
- CoinGecko maps this address on BNB Chain under the same coin: https://www.coingecko.com/en/coins/1inch
- Added via `npm run asset:set`; `npm run asset:verify` and the full test suite pass

Context: the 1inch team reported that MetaMask shows their old logo and name on BNB Chain while Ethereum displays correctly, because this repo has an `eip155:1` entry but no `eip155:56` entry for the token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static token icon and metadata only; no application logic, auth, or data-handling changes.
> 
> **Overview**
> Adds **1INCH** on **BNB Chain** (`eip155:56`) at the same canonical address as Ethereum mainnet (`0x1111…C302`), which was previously missing from this asset list.
> 
> The PR introduces chain-scoped **metadata** (`1INCH Token` / `1INCH` / 18 decimals) and a matching **SVG icon** under the `eip155:56` paths, aligned with the existing `eip155:1` entry so MetaMask and other consumers can show the current logo and name on BNB Chain instead of stale defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbdc11de12bf9aa7368301baab7a1b2109a9139d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->